### PR TITLE
Update git clone instruction to clone submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Hackfest should run on Windows, Linux, however Windows is untested.
 * Instructions for other platforms / distros should be the same, except for 1. step
 
 1. Install packages `mono` `virtualbox` `virtualbox-host-modules-arch` `vagrant` `godot-mono-bit`<sup>AUR</sup>
-2. Clone repo `git clone git@github.com:meowxiik/hackfest.git`
+2. Clone repo `git clone --recursive git@github.com:meowxiik/hackfest.git`
 3. Open Godot, open the cloned project
 4. Navigate to `scenes/Demo` in FileSystem explorer
 5. Run the scene using an icon in upper right corner


### PR DESCRIPTION
The project contains a git submodule at addons/godot-vm-plugin which should also be cloned.